### PR TITLE
Update intro_to_duckdb notebook

### DIFF
--- a/Intro_to_duckdb.ipynb
+++ b/Intro_to_duckdb.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "source": [
     "### Configure the notebook\n",
-    "Set configrations on the ipython sql extension to directly output data to Pandas and to simplify the output that is printed to the notebook."
+    "Set configurations on the ipython sql extension to directly output data to Pandas and to simplify the output that is printed to the notebook."
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%config SqlMagic.autopandAS = True\n",
+    "%config SqlMagic.autopandas = True\n",
     "%config SqlMagic.feedback = False\n",
     "%config SqlMagic.displaycon = False"
    ]
@@ -251,7 +251,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_join = df_join.DataFrame()\n",
     "df_join.head()"
    ]
   },


### PR DESCRIPTION
I had a little issue in the notebook.
`%config SqlMagic.autopandAS = True` was not recognised so I changed it to `%config SqlMagic.autopandas = True`

I guess due to this change the line `df_join.DataFrame()` was raising an error and I had to delete it to make it work. 

![errormessage](https://github.com/rogall-e/DSSG-Data-Engineering-Workshop/assets/60922904/c9e7476d-a6e4-44c5-bfcf-465358dbcb3b)
